### PR TITLE
Salvataggio delle sessioni su Database

### DIFF
--- a/setup/Setup.php
+++ b/setup/Setup.php
@@ -37,6 +37,7 @@ class Setup {
         $_installDir = getcwd();
         $_acsCustomLocation = "";
         $_sloCustomLocation = "";
+        $_storeType = "";
 
         $_serviceName = "myservice";
         $_spName = "Service Provider Name";
@@ -109,6 +110,19 @@ class Setup {
             if ($config['serviceName'] == null || $config['serviceName'] == "") {
                 $config['serviceName'] = $_serviceName;
             }
+        }
+
+        if (!isset($config['storeType'])) {
+            $scelta = "";
+            while ($scelta != "phpsession" && $scelta != "sql") { 
+                echo "Please insert the store type (" .
+                $colors->getColoredString("phpsession", "green") . "|sql): ";
+                $scelta = strtolower(readline());
+                if ($scelta == null || $scelta == "") { 
+                    $scelta = "phpsession";
+                }
+            }
+            $config['storeType'] = $scelta;
         }
 
         if (!isset($config['entityID'])) {
@@ -844,7 +858,11 @@ class Setup {
             "{{TECHCONTACT_EMAIL}}" => "'" . $config['technicalContactEmail'] . "'",
             "{{ACSCUSTOMLOCATION}}" => "'" . $config['acsCustomLocation'] . "'",
             "{{SLOCUSTOMLOCATION}}" => "'" . $config['sloCustomLocation'] . "'",
-            "{{SP_DOMAIN}}" => "'." . $config['spDomain'] . "'"
+            "{{SP_DOMAIN}}" => "'." . $config['spDomain'] . "'",
+            "{{STORETYPE}}" => "'" . $config['storeType'] . "'",
+            "{{STORESQLDNS}}" => "'sqlite:" . ($config['storeType'] == 'sql' ? $config['installDir'] : "/path/to") . "/sqlitedatabase.sq3'",
+            "{{STORESQLUSERNAME}}" => ($config['storeType'] == 'sql' ? "'root'": "null"),
+            "{{STORESQLPASSWORD}}" => ($config['storeType'] == 'sql' ? "'" . bin2hex(random_bytes(8)) . "'": "null")
         );
         $template = file_get_contents($config['installDir'] . '/setup/config/config.tpl', true);
         $customized = str_replace(array_keys($vars), $vars, $template);

--- a/setup/config/config.tpl
+++ b/setup/config/config.tpl
@@ -693,7 +693,7 @@ $config = array(
      *
      * (This option replaces the old 'session.handler'-option.)
      */
-    'store.type'                    => 'phpsession',
+    'store.type'                    => {{STORETYPE}},
 
     /*
      * The DSN the sql datastore should connect to.
@@ -701,13 +701,13 @@ $config = array(
      * See http://www.php.net/manual/en/pdo.drivers.php for the various
      * syntaxes.
      */
-    'store.sql.dsn'                 => 'sqlite:/path/to/sqlitedatabase.sq3',
+    'store.sql.dsn'                 => {{STORESQLDNS}},
 
     /*
      * The username and password to use when connecting to the database.
      */
-    'store.sql.username' => null,
-    'store.sql.password' => null,
+    'store.sql.username' => {{STORESQLUSERNAME}},
+    'store.sql.password' => {{STORESQLPASSWORD}},
 
     /*
      * The prefix we should use on our tables.


### PR DESCRIPTION
Come da issue #159 è stata aggiunta la possibilità salvataggio della sessione simpleSAMLphp su Database.

In fase di setup viene richiesto se utilizzare phpsession o sql (il valore di default è phpsession) per il salvataggio della sessione simpleSAMLphp.
