### PR TITLE
Fixed isCIEEnabled label

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ bool isSPIDEnabled()
 ```
 restituisce true se è stata eseguita le configurazione per SPID, false altrimenti
 
-### isAuthenticated
+### isCIEEnabled
 ```
 bool isCIEEnabled()
 ```


### PR DESCRIPTION
README file reported wrong label for isCIEEnabled() function