### PR TITLE
migliorata configurazione di default

### DIFF
--- a/setup/Setup.php
+++ b/setup/Setup.php
@@ -73,8 +73,8 @@ class Setup {
         $_fpaProvincia = "";
         $_fpaNazione = "IT";
         $_fpaOrganizationName = "";
-        $_fpaOrganizationEmailAddress = "";
-        $_fpaOrganizationTelephoneNumber = "";
+        $_fpaOrganizationEmailAddress = "info@organization.org"; // must be not null otherwise an error is raised in authentication
+        $_fpaOrganizationTelephoneNumber = "+3912345678"; // must be not null otherwise an error is raised in authentication
 
         $config = file_exists("spid-php-setup.json") ?
                 json_decode(file_get_contents("spid-php-setup.json"), true) : array();


### PR DESCRIPTION
Se i due parametri `$_fpaOrganizationEmailAddress` e `$_fpaOrganizationTelephoneNumber` restano vuoti, in fase di autenticazione si ottiene un errore rilevabile solo consultando i log di SimpleSamlPHP. Come in altre circostanze, tanto vale definire un default di esempio in modo da semplificare almeno la fase di test.