### PR TITLE
controllo symlink in Linux

### DIFF
--- a/setup/Setup.php
+++ b/setup/Setup.php
@@ -1013,12 +1013,19 @@ class Setup {
             } catch(Exception $e) {
                 $symlink_manual_creation_command= "WARNING! At the end of the installation execute as administrator this command:\n$mklink_cmd";
             }
-            
+
         } else {
             // linux
-            symlink($cmd_target, $cmd_link);
+            if (is_link($cmd_link)) {
+                if (readlink($cmd_link) != $cmd_target) {
+                    $symlink_manual_creation_command= "WARNING! At the end of the installation check the symbolic link at $cmd_link, it must link to $cmd_target";
+                }
+            }
+            else {
+                symlink($cmd_target, $cmd_link);
+            }
         }
-        
+
         if ($symlink_manual_creation_command === false) {
             echo $colors->getColoredString("OK", "green");
         } else {


### PR DESCRIPTION
Ho aggiunto un piccolo controllo sull'esistenza pregressa del symlink nella DocumentRoot, altrimenti ad ogni aggiornamento successivo all'installazione il comando fallisce.