### PR TITLE
dimensione configurabile per pulsante CIE

### DIFF
--- a/setup/sdk/spid-php.tpl
+++ b/setup/sdk/spid-php.tpl
@@ -539,7 +539,7 @@
             }
 
             echo "<a href=\"?idp=CIE TEST\" class=\"italia-it-button italia-it-button-size-$size button-cie\" aria-haspopup=\"true\" aria-expanded=\"false\">
-                <img src=\"/spid/cie-graphics/SVG/entra_con_cie.svg\" alt=\"Entra con CIE\" />
+                <img src=\"/{{SERVICENAME}}/cie-graphics/SVG/entra_con_cie.svg\" alt=\"Entra con CIE\" />
                 <span class=\"sr-only\" style=\"display:none\">Entra con CIE</span>
             </a>";
         }

--- a/setup/sdk/spid-php.tpl
+++ b/setup/sdk/spid-php.tpl
@@ -532,18 +532,16 @@
             return $button_li;
         }
 
-        public function insertCIEButton($size='default') {
-            echo "
-                <div class=\"cie-button\" style=\"width: 280px;\">
-                    <a class=\"cie-button\" role=\"button\"
-                        href=\"?idp=CIE TEST\" >
-                        <span class=\"cie-button-icon\">
-                            <img aria-hidden=\"true\" src=\"/{{SERVICENAME}}/cie-graphics/SVG/entra_con_cie.svg\" alt=\"Entra con CIE\" />
-                        </span>
-                        <span class=\"sr-only\" style=\"display:none\">Entra con CIE</span>
-                    </a>
-                </div>
-            ";    
+        public function insertCIEButton($size = 'L') {
+            $size = strtolower($size);
+            if ($size == 'default') {
+                $size = 'l';
+            }
+
+            echo "<a href=\"?idp=CIE TEST\" class=\"italia-it-button italia-it-button-size-$size button-cie\" aria-haspopup=\"true\" aria-expanded=\"false\">
+                <img src=\"/spid/cie-graphics/SVG/entra_con_cie.svg\" alt=\"Entra con CIE\" />
+                <span class=\"sr-only\" style=\"display:none\">Entra con CIE</span>
+            </a>";
         }
     }
 


### PR DESCRIPTION
Questa modifica permette di impostare una dimensione per il tasto "Entra con CIE", analogamente a quanto già succede per il tasto SPID. Semplicemente, è stato riscritto il codice che genera il relativo HTML utilizzando le classi CSS già previste dal toolkit.