### PR TITLE
fix: replace array_key_exists with isset on proxy.php

### DIFF
--- a/setup/sdk/proxy.tpl
+++ b/setup/sdk/proxy.tpl
@@ -214,7 +214,7 @@
 
             if($isVerified) {
                 $payload_obj = json_decode($payload);
-                if($decrypt && array_key_exists('data', $payload_obj)) {
+                if($decrypt && isset($payload_obj->data)) {
                     $token = $payload_obj->data;
                     
                     $keyEncryptionAlgorithmManager = new AlgorithmManager([ new A256KW() ]);


### PR DESCRIPTION
array_key_exists on objects was deprecated on PHP 7.4, replaced with isset instead